### PR TITLE
Make sure screen.orientation exists before register onchange event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "videojs-landscape-fullscreen",
-  "version": "0.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "videojs-landscape-fullscreen",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Automatically Switch to Landscape on Fullscreen, and Fullscreen on Landscape",
   "main": "dist/videojs-landscape-fullscreen.cjs.js",
   "module": "dist/videojs-landscape-fullscreen.es.js",

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -77,7 +77,7 @@ const onPlayerReady = (player, options) => {
 
   if (videojs.browser.IS_IOS) {
     window.addEventListener('orientationchange', rotationHandler);
-  } else {
+  } else if (screen && screen.orientation) {
     // addEventListener('orientationchange') is not a user interaction on Android
     screen.orientation.onchange = rotationHandler;
   }


### PR DESCRIPTION
# Why

This fix is checking if `screen.orientation` exists before register `onchange` event.

This is some strange edge case. 

## Error log:

```
TypeError: Cannot set property 'onchange' of undefined
  at Array.forEach (/production_b07cfcf7ebb8414f4246d6c04eb049f00910df2e/vjsfullscreen.d975b8370d43b1717244.es5.js)
  at a (../src/integrations/helpers.ts:77:19)
...
(3 additional frame(s) were not displayed)
```

## User info:

browser: `Chrome Mobile 33.0.1750`
browser.name: `Chrome Mobile`
device: `C1904`
device.family: `C1904`
level `error`
os `Android 4.3`