### PR TITLE
Remove orientation event listener after the player is disposed

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -91,6 +91,10 @@ const onPlayerReady = (player, options) => {
       }
     }
   });
+
+  player.on('dispose', () => {
+    window.removeEventListener('orientationchange', rotationHandler)
+  })
 };
 
 /**


### PR DESCRIPTION
We are adding the orientation event listener which is causing this error when the player is accessed after it's disposed

```
TypeError: Cannot read properties of null (reading 'paused')
  at method(../node_modules/video.js/dist/video.es.js:21454:17)
  at get(../node_modules/video.js/dist/video.es.js:9871:66)
  at techGet_(../node_modules/video.js/dist/video.es.js:23999:14)
  at paused(../node_modules/video.js/dist/video.es.js:24162:17)
  at apply(../node_modules/videojs-landscape-fullscreen/dist/videojs-landscape-fullscreen.es.js:69:18)
  at r(../../src/helpers.ts:87:17)
```

This PR removes that event listener after the player is disposed