### PR TITLE
New options: window mode & rotateWithPause

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ npm install --save videojs-landscape-fullscreen
     enterOnRotate: true,         // Enter fullscreen mode on rotating the device in landscape
     exitOnRotate: true,         // Exit fullscreen mode on rotating the device in portrait
     alwaysInLandscapeMode: true, // Always enter fullscreen in landscape mode even when device is in portrait mode (works on chromium, firefox, and ie >= 11)
+    rotateWithPause: false,  // Unable rotation with pause
+    windowMode: false, // Switch to work with window mode (player.isFullWindow)
     iOS: true //Whether to use fake fullscreen on iOS (needed for displaying player controls instead of system controls)
   }
 };

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -8,6 +8,8 @@ const defaults = {
     enterOnRotate: true,
     exitOnRotate: true,
     alwaysInLandscapeMode: true,
+    rotateWithPause: false,
+    windowMode: false,
     iOS: true
   }
 };
@@ -64,14 +66,24 @@ const onPlayerReady = (player, options) => {
     const currentAngle = angle();
 
     if (currentAngle === 90 || currentAngle === 270 || currentAngle === -90) {
-      if (options.fullscreen.enterOnRotate && player.paused() === false) {
-        player.requestFullscreen();
+      if (options.fullscreen.enterOnRotate && (player.paused() === false || options.fullscreen.rotateWithPause)) {
+        if(options.fullscreen.windowMode){
+          player.enterFullWindow();
+        }
+        if(!options.fullscreen.windowMode){
+          player.requestFullscreen();
+        }
         screen.lockOrientationUniversal('landscape');
       }
     }
     if (currentAngle === 0 || currentAngle === 180) {
       if (options.fullscreen.exitOnRotate && player.isFullscreen()) {
-        player.exitFullscreen();
+        if(options.fullscreen.windowMode){
+          player.exitFullWindow();
+        }
+        if(!options.fullscreen.windowMode){
+          player.exitFullscreen();
+        }
       }
     }
   };


### PR DESCRIPTION
In my web project, I use a custom video player based on videojs. For iOS devices, I also need support for this custom player UI. My solution involves using the player.isFullWindow property, but there are bugs when toggling because isFullScreen and isFullWindow are not synchronized. So I added support for this property