### PR TITLE
Fix version export warning

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,6 +1,8 @@
 import videojs from 'video.js';
-import {version as VERSION} from '../package.json';
+import packageJson from '../package.json';
 import window from 'global/window';
+
+const VERSION = packageJson.version;
 
 // Default options for the plugin.
 const defaults = {


### PR DESCRIPTION
Fixes warning:
```
WARNING in ./node_modules/videojs-landscape-fullscreen/src/plugin.js 124:30-37 Should not import the named export 'version' (imported as 'VERSION') from default-exporting module (only default export is available soon)
```